### PR TITLE
Fix Composer package name property

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "wp-typeit",
+  "name": "alexmacarthur/wp-typeit",
   "description": "Easily create and manage typewriter effects using the JavaScript utility, TypeIt.",
   "type": "wordpress-plugin",
   "minimum-stability": "stable",


### PR DESCRIPTION
The name of the package consists of vendor name and project name, separated by /